### PR TITLE
fix: Increase delay in VM stop provisioners to 30s

### DIFF
--- a/vms/create_vms.tf
+++ b/vms/create_vms.tf
@@ -80,7 +80,7 @@ resource "null_resource" "stop_lax_linux_01" {
   depends_on = [google_compute_instance.lax-linux-01]
 
   provisioner "local-exec" {
-    command = "sleep 10 && gcloud compute instances stop lax-linux-01 --zone=us-west2-c || true"
+    command = "sleep 30 && gcloud compute instances stop lax-linux-01 --zone=us-west2-c || true"
   }
 }
 
@@ -159,7 +159,7 @@ resource "null_resource" "stop_lax_linux_02" {
   depends_on = [google_compute_instance.lax-linux-02]
 
   provisioner "local-exec" {
-    command = "sleep 10 && gcloud compute instances stop lax-linux-02 --zone=us-west2-c || true"
+    command = "sleep 30 && gcloud compute instances stop lax-linux-02 --zone=us-west2-c || true"
   }
 }
 
@@ -238,7 +238,7 @@ resource "null_resource" "stop_lax_linux_03" {
   depends_on = [google_compute_instance.lax-linux-03]
 
   provisioner "local-exec" {
-    command = "sleep 10 && gcloud compute instances stop lax-linux-03 --zone=us-west2-c || true"
+    command = "sleep 30 && gcloud compute instances stop lax-linux-03 --zone=us-west2-c || true"
   }
 }
 
@@ -317,7 +317,7 @@ resource "null_resource" "stop_lax_linux_04" {
   depends_on = [google_compute_instance.lax-linux-04]
 
   provisioner "local-exec" {
-    command = "sleep 10 && gcloud compute instances stop lax-linux-04 --zone=us-west2-c || true"
+    command = "sleep 30 && gcloud compute instances stop lax-linux-04 --zone=us-west2-c || true"
   }
 }
 


### PR DESCRIPTION
This commit increases the delay in the `local-exec` provisioner command from 10 seconds to 30 seconds for each of the four `null_resource` definitions responsible for stopping the VMs (`stop_lax_linux_01` through `stop_lax_linux_04`).

This change aims to further improve the robustness of the auto-stop mechanism by allowing more time for newly created VMs to become fully ready for API interactions before the stop command is issued.