### PR TITLE
fix: Target correct project in VM stop provisioners

### DIFF
--- a/vms/create_vms.tf
+++ b/vms/create_vms.tf
@@ -80,7 +80,7 @@ resource "null_resource" "stop_lax_linux_01" {
   depends_on = [google_compute_instance.lax-linux-01]
 
   provisioner "local-exec" {
-    command = "sleep 30 && gcloud compute instances stop lax-linux-01 --zone=us-west2-c || true"
+    command = "sleep 30 && gcloud compute instances stop lax-linux-01 --zone=us-west2-c --project=glabco-sp-1 || true"
   }
 }
 
@@ -159,7 +159,7 @@ resource "null_resource" "stop_lax_linux_02" {
   depends_on = [google_compute_instance.lax-linux-02]
 
   provisioner "local-exec" {
-    command = "sleep 30 && gcloud compute instances stop lax-linux-02 --zone=us-west2-c || true"
+    command = "sleep 30 && gcloud compute instances stop lax-linux-02 --zone=us-west2-c --project=glabco-sp-1 || true"
   }
 }
 
@@ -238,7 +238,7 @@ resource "null_resource" "stop_lax_linux_03" {
   depends_on = [google_compute_instance.lax-linux-03]
 
   provisioner "local-exec" {
-    command = "sleep 30 && gcloud compute instances stop lax-linux-03 --zone=us-west2-c || true"
+    command = "sleep 30 && gcloud compute instances stop lax-linux-03 --zone=us-west2-c --project=glabco-sp-1 || true"
   }
 }
 
@@ -317,7 +317,7 @@ resource "null_resource" "stop_lax_linux_04" {
   depends_on = [google_compute_instance.lax-linux-04]
 
   provisioner "local-exec" {
-    command = "sleep 30 && gcloud compute instances stop lax-linux-04 --zone=us-west2-c || true"
+    command = "sleep 30 && gcloud compute instances stop lax-linux-04 --zone=us-west2-c --project=glabco-sp-1 || true"
   }
 }
 


### PR DESCRIPTION
This commit corrects the `gcloud` commands within the `local-exec` provisioners for all four VMs (`stop_lax_linux_01` through `stop_lax_linux_04`).

The `--project=glabco-sp-1` flag has been added to each `gcloud compute instances stop` command. This ensures that the command targets the `glabco-sp-1` project, where the VMs are defined, rather than relying on the default project of the Terraform execution environment. This fixes a bug where provisioners might fail if the default project is different (e.g., `glabco-bdr-1`).