### PR TITLE
Fix: Add explicit dependencies for backup plan associations

### DIFF
--- a/backup_disk_workloads.tf
+++ b/backup_disk_workloads.tf
@@ -41,6 +41,9 @@ resource "google_backup_dr_backup_plan_association" "lax_linux_03_plan_associati
   backup_plan_association_id          = "lax-linux-03-disk-plan-assoc"
   backup_plan = google_backup_dr_backup_plan.us-disk-backup-plan-1.id
   resource_type= "compute.googleapis.com/Disk" # for Regional Disk use /RegionDisk instead of /Disk
+  depends_on = [
+    google_compute_instance.lax-linux-03
+  ]
 }
 
 resource "google_backup_dr_backup_plan_association" "lax_linux_03-d1_plan_association" {
@@ -51,6 +54,9 @@ resource "google_backup_dr_backup_plan_association" "lax_linux_03-d1_plan_associ
   backup_plan_association_id          = "lax-linux-03-disk-d1-plan-assoc"
   backup_plan = google_backup_dr_backup_plan.us-disk-backup-plan-1.id
   resource_type= "compute.googleapis.com/Disk" # for Regional Disk use /RegionDisk instead of /Disk
+  depends_on = [
+    google_compute_disk.lax_linux_03_disk_1
+  ]
 }
 
 resource "google_backup_dr_backup_plan_association" "lax_linux_04_plan_association" {
@@ -61,6 +67,9 @@ resource "google_backup_dr_backup_plan_association" "lax_linux_04_plan_associati
   backup_plan_association_id          = "lax-linux-04-disk-plan-assoc"
   backup_plan = google_backup_dr_backup_plan.us-disk-backup-plan-1.id
   resource_type= "compute.googleapis.com/Disk" # for Regional Disk use /RegionDisk instead of /Disk
+  depends_on = [
+    google_compute_instance.lax-linux-04
+  ]
 }
 
 resource "google_backup_dr_backup_plan_association" "lax_linux_04-d1_plan_association" {
@@ -71,4 +80,7 @@ resource "google_backup_dr_backup_plan_association" "lax_linux_04-d1_plan_associ
   backup_plan_association_id          = "lax-linux-04-disk-d1-plan-assoc"
   backup_plan = google_backup_dr_backup_plan.us-disk-backup-plan-1.id
   resource_type= "compute.googleapis.com/Disk" # for Regional Disk use /RegionDisk instead of /Disk
+  depends_on = [
+    google_compute_disk.lax_linux_04_disk_1
+  ]
 }

--- a/backup_vm_workloads.tf
+++ b/backup_vm_workloads.tf
@@ -29,6 +29,9 @@ resource "google_backup_dr_backup_plan_association" "lax_linux_01_plan_associati
   backup_plan_association_id          = "lax-linux-01-basic-plan-assoc"
   backup_plan = google_backup_dr_backup_plan.us-vm-backup-plan-1.id
   resource_type= "compute.googleapis.com/Instance"
+  depends_on = [
+    google_compute_instance.lax-linux-01
+  ]
 }
 
 resource "google_backup_dr_backup_plan_association" "lax_linux_02_plan_association" {
@@ -39,4 +42,7 @@ resource "google_backup_dr_backup_plan_association" "lax_linux_02_plan_associati
   backup_plan_association_id          = "lax-linux-02-basic-plan-assoc"
   backup_plan = google_backup_dr_backup_plan.us-vm-backup-plan-1.id
   resource_type= "compute.googleapis.com/Instance"
+  depends_on = [
+    google_compute_instance.lax-linux-02
+  ]
 }


### PR DESCRIPTION
I've added `depends_on` clauses to `google_backup_dr_backup_plan_association` resources in both `backup_disk_workloads.tf` and `backup_vm_workloads.tf`.

This ensures that your compute instances and disks are fully created before Terraform attempts to create backup plan associations for them, resolving potential "resource not found" errors during `terraform apply`.

Specifically:
- Disk backup associations now explicitly depend on their corresponding `google_compute_disk` or `google_compute_instance` (for boot disks) resources.
- VM backup associations now explicitly depend on their corresponding `google_compute_instance` resources.