### PR TITLE
Fix: Replace all data sources with direct refs for backup associations

### DIFF
--- a/backup_disk_workloads.tf
+++ b/backup_disk_workloads.tf
@@ -9,18 +9,6 @@ provider "google" {
 }
 
 # Backup and DR Workload definitions will be added here.
-data "google_compute_disk" "lax_linux_03-d1" {
-  provider = google.gcp_disk # Use the provider for the project where the Disk exists
-  name     = "lax-linux-03-disk-1"
-  zone     = "us-west2-c"       # Zone of the lax-linux-01 VM
-}
-
-data "google_compute_disk" "lax_linux_04-d1" {
-  provider = google.gcp_disk # Use the provider for the project where the Disk exists
-  name     = "lax-linux-04-disk-1"
-  zone     = "us-west2-c"       # Zone of the lax-linux-02 VM
-}
-
 resource "google_backup_dr_backup_plan_association" "lax_linux_03_plan_association" {
   provider = google.gcp_bdr
   project  = "glabco-sp-1"
@@ -38,7 +26,7 @@ resource "google_backup_dr_backup_plan_association" "lax_linux_03-d1_plan_associ
   provider = google.gcp_bdr
   project  = "glabco-sp-1"
   location = "us-west2"
-  resource = data.google_compute_disk.lax_linux_03-d1.id
+  resource = google_compute_disk.lax_linux_03_disk_1.self_link
   backup_plan_association_id          = "lax-linux-03-disk-d1-plan-assoc"
   backup_plan = google_backup_dr_backup_plan.us-disk-backup-plan-1.id
   resource_type= "compute.googleapis.com/Disk" # for Regional Disk use /RegionDisk instead of /Disk
@@ -64,7 +52,7 @@ resource "google_backup_dr_backup_plan_association" "lax_linux_04-d1_plan_associ
   provider = google.gcp_bdr
   project  = "glabco-sp-1"
   location = "us-west2"
-  resource = data.google_compute_disk.lax_linux_04-d1.id
+  resource = google_compute_disk.lax_linux_04_disk_1.self_link
   backup_plan_association_id          = "lax-linux-04-disk-d1-plan-assoc"
   backup_plan = google_backup_dr_backup_plan.us-disk-backup-plan-1.id
   resource_type= "compute.googleapis.com/Disk" # for Regional Disk use /RegionDisk instead of /Disk

--- a/backup_vm_workloads.tf
+++ b/backup_vm_workloads.tf
@@ -9,23 +9,11 @@ provider "google" {
 }
 
 # Backup and DR Workload definitions will be added here.
-data "google_compute_instance" "lax_linux_01" {
-  provider = google.gcp_compute # Use the provider for the project where the VM exists
-  name     = "lax-linux-01"
-  zone     = "us-west2-c"       # Zone of the lax-linux-01 VM
-}
-
-data "google_compute_instance" "lax_linux_02" {
-  provider = google.gcp_compute # Use the provider for the project where the VM exists
-  name     = "lax-linux-02"
-  zone     = "us-west2-c"       # Zone of the lax-linux-02 VM
-}
-
 resource "google_backup_dr_backup_plan_association" "lax_linux_01_plan_association" {
   provider = google.gcp_bdr
   project  = "glabco-sp-1"
   location = "us-west2"
-  resource = data.google_compute_instance.lax_linux_01.id # The resource to associate
+  resource = google_compute_instance.lax-linux-01.self_link # The resource to associate
   backup_plan_association_id          = "lax-linux-01-basic-plan-assoc"
   backup_plan = google_backup_dr_backup_plan.us-vm-backup-plan-1.id
   resource_type= "compute.googleapis.com/Instance"
@@ -38,7 +26,7 @@ resource "google_backup_dr_backup_plan_association" "lax_linux_02_plan_associati
   provider = google.gcp_bdr
   project  = "glabco-sp-1"
   location = "us-west2"
-  resource = data.google_compute_instance.lax_linux_02.id # The resource to associate
+  resource = google_compute_instance.lax-linux-02.self_link # The resource to associate
   backup_plan_association_id          = "lax-linux-02-basic-plan-assoc"
   backup_plan = google_backup_dr_backup_plan.us-vm-backup-plan-1.id
   resource_type= "compute.googleapis.com/Instance"


### PR DESCRIPTION
Replaced all `data "google_compute_disk"` and `data "google_compute_instance"` sources in `backup_disk_workloads.tf` and `backup_vm_workloads.tf` with direct resource references (using `.self_link` or `.boot_disk[0].source`).

This ensures that Terraform's dependency graph correctly orders the creation of instances and disks before their backup plan associations, preventing "resource not found" errors that occurred when data sources were evaluated too early in the apply process.

The `depends_on` attributes on the association resources have been maintained to explicitly reinforce these dependencies.