### PR TITLE
Refactor: Configure Terraform for multi-project deployment

### DIFF
--- a/backup_disk_workloads.tf
+++ b/backup_disk_workloads.tf
@@ -1,13 +1,6 @@
 # This file defines Backup and DR workload configurations to associate Disks
 # with backup plans.
 
-# Provider for the GCE instances in glabco-sp-1
-provider "google" {
-  alias   = "gcp_disk"
-  project = "glabco-sp-1"
-  region  = "us-west2" # VMs are in us-west2, so setting region for this provider
-}
-
 # Backup and DR Workload definitions will be added here.
 resource "google_backup_dr_backup_plan_association" "lax_linux_03_plan_association" {
   provider = google.gcp_bdr

--- a/backup_plans.tf
+++ b/backup_plans.tf
@@ -1,6 +1,7 @@
 # Create Backup Plans for VMs and Disks with multiple Rules
 
 resource "google_backup_dr_backup_plan" "au-vm-backup-plan-1" {
+  provider       = google.gcp_bdr
   location       = "australia-southeast1"
   backup_plan_id = "gold-vm-backup-plan-au-1"
   resource_type  = "compute.googleapis.com/Instance"
@@ -70,6 +71,7 @@ resource "google_backup_dr_backup_plan" "au-vm-backup-plan-1" {
 }
 
 resource "google_backup_dr_backup_plan" "au-vm-backup-plan-2" {
+  provider       = google.gcp_bdr
   location       = "australia-southeast1"
   backup_plan_id = "silver-vm-backup-plan-au-2"
   resource_type  = "compute.googleapis.com/Instance"
@@ -109,6 +111,7 @@ resource "google_backup_dr_backup_plan" "au-vm-backup-plan-2" {
 }
 
 resource "google_backup_dr_backup_plan" "au-vm-backup-plan-3" {
+  provider       = google.gcp_bdr
   location       = "australia-southeast1"
   backup_plan_id = "bronze-vm-backup-plan-au-3"
   resource_type  = "compute.googleapis.com/Instance"
@@ -133,6 +136,7 @@ resource "google_backup_dr_backup_plan" "au-vm-backup-plan-3" {
 }
 
 resource "google_backup_dr_backup_plan" "us-vm-backup-plan-1" {
+  provider       = google.gcp_bdr
   location       = "us-west2"
   backup_plan_id = "basic-vm-backup-plan-us-1"
   resource_type  = "compute.googleapis.com/Instance"
@@ -159,6 +163,7 @@ resource "google_backup_dr_backup_plan" "us-vm-backup-plan-1" {
 # Create Backup Plans for Disk with multiple Rules
 
 resource "google_backup_dr_backup_plan" "us-disk-backup-plan-1" {
+  provider       = google.gcp_bdr
   location       = "us-west2"
   backup_plan_id = "basic-disks-backup-plan-us-1"
   resource_type  = "compute.googleapis.com/Disk"

--- a/backup_vaults.tf
+++ b/backup_vaults.tf
@@ -16,6 +16,7 @@ terraform {
 }
 
 provider "google" {
+  alias   = "gcp_bdr"
   project = "glabco-bdr-1"
 }
 

--- a/backup_vm_workloads.tf
+++ b/backup_vm_workloads.tf
@@ -1,13 +1,6 @@
 # This file defines Backup and DR workload configurations to associate VMs
 # with backup plans.
 
-# Provider for the GCE instances in glabco-sp-1
-provider "google" {
-  alias   = "gcp_compute"
-  project = "glabco-sp-1"
-  region  = "us-west2" # VMs are in us-west2, so setting region for this provider
-}
-
 # Backup and DR Workload definitions will be added here.
 resource "google_backup_dr_backup_plan_association" "lax_linux_01_plan_association" {
   provider = google.gcp_bdr

--- a/create_vms.tf
+++ b/create_vms.tf
@@ -1,8 +1,16 @@
 # This code is compatible with Terraform 4.25.0 and versions that are backward compatible to 4.25.0.
 # For information about validating this Terraform code, see https://developer.hashicorp.com/terraform/tutorials/gcp-get-started/google-cloud-platform-build#format-and-validate-the-configuration
 
+provider "google" {
+  alias   = "gcp_compute"
+  project = "glabco-sp-1"
+  # You might need to specify the region if not all resources in this file use the same one,
+  # or if the default region for the provider isn't us-west2.
+  # For now, we assume zone is specified in each resource, or region is inherited correctly.
+}
 
 resource "google_compute_instance" "lax-linux-01" {
+  provider = google.gcp_compute
   attached_disk {
     source      = google_compute_disk.lax_linux_01_disk_1.name
     device_name = "lax-linux-01-data-disk"
@@ -67,6 +75,7 @@ resource "google_compute_instance" "lax-linux-01" {
 }
 
 resource "google_compute_disk" "lax_linux_01_disk_1" {
+  provider = google.gcp_compute
   name  = "lax-linux-01-disk-1"
   type  = "pd-standard"
   size  = 10
@@ -82,6 +91,7 @@ resource "null_resource" "stop_lax_linux_01" {
 }
 
 resource "google_compute_instance" "lax-linux-02" {
+  provider = google.gcp_compute
   attached_disk {
     source      = google_compute_disk.lax_linux_02_disk_1.name
     device_name = "lax-linux-02-data-disk"
@@ -146,6 +156,7 @@ resource "google_compute_instance" "lax-linux-02" {
 }
 
 resource "google_compute_disk" "lax_linux_02_disk_1" {
+  provider = google.gcp_compute
   name  = "lax-linux-02-disk-1"
   type  = "pd-standard"
   size  = 10
@@ -161,6 +172,7 @@ resource "null_resource" "stop_lax_linux_02" {
 }
 
 resource "google_compute_instance" "lax-linux-03" {
+  provider = google.gcp_compute
   attached_disk {
     source      = google_compute_disk.lax_linux_03_disk_1.name
     device_name = "lax-linux-03-data-disk"
@@ -225,6 +237,7 @@ resource "google_compute_instance" "lax-linux-03" {
 }
 
 resource "google_compute_disk" "lax_linux_03_disk_1" {
+  provider = google.gcp_compute
   name  = "lax-linux-03-disk-1"
   type  = "pd-standard"
   size  = 10
@@ -240,6 +253,7 @@ resource "null_resource" "stop_lax_linux_03" {
 }
 
 resource "google_compute_instance" "lax-linux-04" {
+  provider = google.gcp_compute
   attached_disk {
     source      = google_compute_disk.lax_linux_04_disk_1.name
     device_name = "lax-linux-04-data-disk"
@@ -304,6 +318,7 @@ resource "google_compute_instance" "lax-linux-04" {
 }
 
 resource "google_compute_disk" "lax_linux_04_disk_1" {
+  provider = google.gcp_compute
   name  = "lax-linux-04-disk-1"
   type  = "pd-standard"
   size  = 10


### PR DESCRIPTION
I've explicitly defined and assigned providers for different Google Cloud projects:
- VMs and Disks (`create_vms.tf`) are now managed under project `glabco-sp-1` using the `google.gcp_compute` provider.
- Backup Vaults (`backup_vaults.tf`) and Backup Plans (`backup_plans.tf`) are managed under project `glabco-bdr-1` using the `google.gcp_bdr` provider.
- Backup Plan Associations (`backup_vm_workloads.tf`, `backup_disk_workloads.tf`) are created in project `glabco-sp-1` but utilize the `google.gcp_bdr` provider, correctly linking resources across projects.

This change ensures that resources are created and managed in their designated projects as per your infrastructure requirements. I removed redundant local provider blocks, and resources now explicitly use aliased providers for clarity and correctness.