### PR TITLE
Fix: Consolidate duplicate gcp_bdr provider alias

### DIFF
--- a/backup_dr_alerts.tf
+++ b/backup_dr_alerts.tf
@@ -1,11 +1,4 @@
 # This file is for configuring alerts related to Google Cloud Backup and DR.
-# Provider for Backup & DR resources in the glabco-bdr-1 project
-provider "google" {
-  alias   = "gcp_bdr"
-  project = "glabco-bdr-1"
-  # region  = "us-west1" # Optional: specify if needed
-}
-
 # Resources for logging metric, alert policy, and notification channel will be added here.
 resource "google_monitoring_notification_channel" "backup_dr_failure_email_channel" {
   provider     = google.gcp_bdr


### PR DESCRIPTION
I removed the duplicate `provider "google" { alias = "gcp_bdr" ... }` block from `backup_dr_alerts.tf`.

This resolves a "Duplicate provider configuration" error. Resources in `backup_dr_alerts.tf` were already correctly referencing `google.gcp_bdr` and will now use the definition of this provider alias located in `backup_vaults.tf`. This ensures a single source of truth for the `gcp_bdr` provider configuration within project `glabco-bdr-1`.